### PR TITLE
Release UE React Native SDK 4.0.2

### DIFF
--- a/react-native-userexperior/UserExperior.js
+++ b/react-native-userexperior/UserExperior.js
@@ -3,7 +3,7 @@ var { NativeModules, findNodeHandle, InteractionManager } = require('react-nativ
 var UserExperiorBridge = NativeModules.UserExperior;
 
 const fw = "rn"; // framework: React-Native
-const sv = "4.0.1"; // SDK/Plugin Version
+const sv = "4.0.2"; // SDK/Plugin Version
 
 class UserExperior {
 

--- a/react-native-userexperior/android/build.gradle
+++ b/react-native-userexperior/android/build.gradle
@@ -41,7 +41,7 @@ android {
 dependencies {
     //compile(name: 'userexperiorsdk-V2-2-04202018', ext: 'aar')
     //compile 'com.userexperior:userexperior-android:1.8.0-SNAPSHOT'
-	implementation 'com.userexperior:userexperior-android:7.3.7'
+	implementation 'com.userexperior:userexperior-android:7.3.8'
 
 	implementation 'com.facebook.react:react-native:+'
 }

--- a/react-native-userexperior/package.json
+++ b/react-native-userexperior/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-userexperior",
-  "version": "4.0.1",
+  "version": "4.0.2",
   "spec": "latest",
   "description": "UserExperior react native module",
   "main": "index.js",


### PR DESCRIPTION
# Description

### What's new in this release?

- Debouncer Implementation to fix Mirae Asset ANRs
- Fixed setUserProperties(...) to append all the properties if it is called multiple times, raised by IndusInd
- The getActiveNetworkInfo() call was deprecated so it was replaced with the latest method, also removed usage of TelephonyManager as it required explicit READ_PHONE_STATE permission to avoid any crashes - Clients: ABCD, Bajaj Finserv, now for Network Type, we won't be detecting 2G/3G/4G/5G due to Google Restrictions and dangerous permissions required, we will only show either Cellular or WiFi
- Nuvama was facing crashes on Android 13 due to bad bitmap handling. Handled the recycling of bitmap based on Android version

# Link(s)

- [ISS-129250](https://app.devrev.ai/devrev/works/ISS-129250)